### PR TITLE
Add support for here strings (`<<<`)

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -3,7 +3,7 @@
 // '<(' is process substitution operator and
 // can be parsed the same as control operator
 var CONTROL = '(?:' + [
-	'\\|\\|', '\\&\\&', ';;', '\\|\\&', '\\<\\(', '>>', '>\\&', '<\\&', '[&;()|<>]'
+	'\\|\\|', '\\&\\&', ';;', '\\|\\&', '\\<\\(', '\\<\\<\\<', '>>', '>\\&', '<\\&', '[&;()|<>]'
 ].join('|') + ')';
 var META = '|&;()<> \\t';
 var BAREWORD = '(\\\\[\'"' + META + ']|[^\\s\'"' + META + '])+';

--- a/test/env.js
+++ b/test/env.js
@@ -23,6 +23,15 @@ test('expand environment variables', function (t) {
 	t.end();
 });
 
+test('expand environment variables within here-strings', function (t) {
+	t.same(parse('a <<< $x', { x: 'Joe' }), ['a', { op: '<<<' }, 'Joe']);
+	t.same(parse('a <<< ${x}', { x: 'Joe' }), ['a', { op: '<<<' }, 'Joe']);
+	t.same(parse('a <<< "$x"', { x: 'Joe' }), ['a', { op: '<<<' }, 'Joe']);
+	t.same(parse('a <<< "${x}"', { x: 'Joe' }), ['a', { op: '<<<' }, 'Joe']);
+
+	t.end();
+});
+
 test('environment variables with metacharacters', function (t) {
 	t.same(parse('a $XYZ c', { XYZ: '"b"' }), ['a', '"b"', 'c']);
 	t.same(parse('a $XYZ c', { XYZ: '$X', X: 5 }), ['a', '$X', 'c']);

--- a/test/op.js
+++ b/test/op.js
@@ -82,6 +82,15 @@ test('duplicating input file descriptors', function (t) {
 	t.end();
 });
 
+test('here strings', function (t) {
+	t.same(parse('cat <<< "hello world"'), ['cat', { op: '<<<' }, 'hello world']);
+	t.same(parse('cat <<< hello'), ['cat', { op: '<<<' }, 'hello']);
+	t.same(parse('cat<<<hello'), ['cat', { op: '<<<' }, 'hello']);
+	t.same(parse('cat<<<"hello world"'), ['cat', { op: '<<<' }, 'hello world']);
+
+	t.end();
+});
+
 test('glob patterns', function (t) {
 	t.same(
 		parse('tap test/*.test.js'),


### PR DESCRIPTION
This PR extends the parser to support the [Bash "here" strings](https://tldp.org/LDP/abs/html/x17837.html) operator, i.e. `<<<` in scenarios such as:

```bash
$ tr a-z A-Z <<< hello
HELLO
$ 
```

(Note: the `<<<` syntax is not supported on all shells but is supported on, for example, Bash and Zsh)