### PR TITLE
Add syntax support for duplicating input file descriptors

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -3,7 +3,7 @@
 // '<(' is process substitution operator and
 // can be parsed the same as control operator
 var CONTROL = '(?:' + [
-	'\\|\\|', '\\&\\&', ';;', '\\|\\&', '\\<\\(', '>>', '>\\&', '[&;()|<>]'
+	'\\|\\|', '\\&\\&', ';;', '\\|\\&', '\\<\\(', '>>', '>\\&', '<\\&', '[&;()|<>]'
 ].join('|') + ')';
 var META = '|&;()<> \\t';
 var BAREWORD = '(\\\\[\'"' + META + ']|[^\\s\'"' + META + '])+';

--- a/test/op.js
+++ b/test/op.js
@@ -69,6 +69,19 @@ test('double operators', function (t) {
 	t.end();
 });
 
+test('duplicating input file descriptors', function (t) {
+	// duplicating stdout to file descriptor 3
+	t.same(parse('beep 3<&1'), ['beep', '3', { op: '<&' }, '1']);
+
+	// duplicating stdout to file descriptor 0, i.e. stdin
+	t.same(parse('beep <&1'), ['beep', { op: '<&' }, '1']);
+
+	// closes stdin
+	t.same(parse('beep <&-'), ['beep', { op: '<&' }, '-']);
+
+	t.end();
+});
+
 test('glob patterns', function (t) {
 	t.same(
 		parse('tap test/*.test.js'),


### PR DESCRIPTION
This PR extends the parser to support the `n<&m` [Bash syntax for duplicating input file descriptors](https://www.gnu.org/software/bash/manual/html_node/Redirections.html#Duplicating-File-Descriptors), i.e.:

```bash
echo "hello" > file.txt  # create a file named "file.txt"
exec 3<file.txt          # assign file descriptor 3 to "file.txt"
wc -l <&3                # redirect stdin to fd 3, i.e. read it from "file.txt"
```