### PR TITLE
Fix quote - was severely broken

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,29 @@
 exports.quote = function (xs) {
     return xs.map(function (s) {
         if (s && typeof s === 'object') {
-            return s.op.replace(/(.)/g, '\\$1');
+            return s.op;
         }
-        else if (/["\s]/.test(s) && !/'/.test(s)) {
-            return "'" + s.replace(/(['\\])/g, '\\$1') + "'";
+        // Enclose strings with metacharacters in single quoted,
+        // and escape any single quotes.
+        // Match strictly to avoid escaping things that don't need to be.
+        // bash: |  & ; ( ) < > space tab
+        // Also escapes bash curly brace ranges {a..b} {a..z..3} {1..20} {a,b} but not
+        // {a...b} or {..a}
+        if ((/(?:["\\$`!\s|&;\(\)<>]|{[\d]+\.{2}[\d]+(?:\.\.\d+)?}|{[a-zA-Z].{2}[a-zA-Z](?:\.\.\d+)?}|{[^{]*,[^}]*})/m).test(s)) {
+            // If input contains outer single quote, escape each of them individually.
+            // eg. 'a b c' -> \''a b c'\'
+            var outer_quotes = s.match(/^('*)(.*?)('*)$/s);
+
+            // the starting outer quotes individually escaped
+            return String(outer_quotes[1]).replace(/(.)/g, '\\$1') +
+                // the text inside the outer single quotes is single quoted
+                "'" + outer_quotes[2].replace(/'/g, '\'\\\'\'') + "'" +
+                // the ending outer quotes individually escaped
+                String(outer_quotes[3]).replace(/(.)/g, '\\$1');
         }
-        else if (/["'\s]/.test(s)) {
-            return '"' + s.replace(/(["\\$`(){}!#&*|])/g, '\\$1') + '"';
-        }
-        else {
-            return s.replace(/([\\$`(){}!#&*|])/g, '\\$1');
-        }
+        // Only escape the single quotes in strings without metachars or
+        // separators
+        return String(s).replace(/(')/g, '\\$1');
     }).join(' ');
 };
 

--- a/test/quote.js
+++ b/test/quote.js
@@ -2,20 +2,82 @@ var test = require('tape');
 var quote = require('../').quote;
 
 test('quote', function (t) {
-    t.equal(quote([ 'a', 'b', 'c d' ]), 'a b \'c d\'');
-    t.equal(
-        quote([ 'a', 'b', "it's a \"neat thing\"" ]),
-        'a b "it\'s a \\"neat thing\\""'
-    );
-    t.equal(
-        quote([ '$', '`', '\'' ]),
-        '\\$ \\` "\'"'
-    );
-    t.equal(quote([]), '');
-    t.end();
+	t.equal(quote(['a', 'b', 'c d']), "a b 'c d'");
+	var quoted = quote(['a', 'b', "it's a \"neat thing\""]);
+	t.equal(
+		quoted,
+		'a b \'it\'\\\'\'s a "neat thing"\''
+	);
+	t.isEqual(quoted.length, 28);
+	t.equal(
+		quote(['$', '`', '\'']),
+		'\'$\' \'`\' \\\''
+	);
+	t.equal(quote([]), '');
+	t.equal(quote(["'"]), "\\'");
+	t.equal(quote(["''"]), "\\'\\'");
+	t.equal(quote(['a\nb']), "'a\nb'");
+	t.equal(quote([' #(){}*|][!']), "' #(){}*|][!'");
+	t.equal(quote(["'#(){}*|][!"]), "\\''#(){}*|][!'");
+	t.equal(quote(["'#(){}*|][!"]), '\\\'\'#(){}*|][!\'');
+	t.equal(quote(['X#(){}*|][!']), "'X#(){}*|][!'");
+	t.equal(quote(['a\n#\nb']), "'a\n#\nb'");
+	t.equal(quote(['><;{}']), "'><;{}'");
+	t.equal(quote(['a', 1, true, false]), 'a 1 true false');
+	t.equal(quote(['a', 1, null, undefined]), 'a 1 null undefined');
+	t.equal(quote(['a\\x']), "'a\\x'");
+
+	// Bash brace expansions {a,b} or {a..b} must be quoted
+	t.equal(quote(['a{1,2}']), "'a{1,2}'");
+	t.equal(quote(['a{,2}']), "'a{,2}'");
+	t.equal(quote(['a{,,2}']), "'a{,,2}'");
+	t.equal(quote(['\'a{,,2}\'']), "\\''a{,,2}'\\'");
+	t.equal(quote(['a{1..2}']), "'a{1..2}'");
+	t.equal(quote(['a{X..Z}']), "'a{X..Z}'");
+	t.equal(quote(['a{{1..2}}']), "'a{{1..2}}'");
+
+	// ... but non brace expansions should not be
+	t.equal(quote(['a{1...2}']), "a{1...2}");
+	t.equal(quote(['a{1...2}']), "a{1...2}");
+	t.equal(quote(['a{1..Z}']), "a{1..Z}");
+	t.equal(quote(['a{a1..b1}']), "a{a1..b1}");
+	t.equal(quote(['a{1a..4}']), "a{1a..4}");
+	t.equal(quote(['a{..6}']), "a{..6}");
+	t.equal(quote(['a{{1...2}}']), "a{{1...2}}");
+	t.equal(quote(['a{1.2}']), "a{1.2}");
+	t.equal(quote(['a{{1.2}}']), "a{{1.2}}");
+	t.equal(quote(['a{12}']), "a{12}");
+	quoted = quote(['\\ \\']);
+	t.equal(quoted, "'\\ \\'");
+	t.isEqual(quoted.length, 5); // 3-char string + 2 quotes
+	// TODO: Ugly expansion of single quote at beginning or end of strings.
+	// Should return \'
+	t.equal(quote(["'$'"]), "\\''$'\\'");
+	t.equal(quote(["'"]), "\\'");
+	t.equal(quote(['gcc', '-DVAR=value']), 'gcc -DVAR=value');
+	t.equal(quote(['gcc', '-DVAR=value with space']), "gcc '-DVAR=value with space'");
+	t.end();
 });
 
 test('quote ops', function (t) {
-    t.equal(quote([ 'a', { op: '|' }, 'b' ]), 'a \\| b');
-    t.end();
+	t.equal(quote(['a', { op: '|' }, 'b']), 'a | b');
+	t.equal(
+		quote(['a', { op: '&&' }, 'b', { op: ';' }, 'c']),
+		'a && b ; c'
+	);
+	t.end();
+});
+
+test('quote windows paths', { skip: 'breaking change, disabled until 2.x' }, function (t) {
+	var path = 'C:\\projects\\node-shell-quote\\index.js';
+
+	t.equal(quote([path, 'b', 'c d']), 'C:\\projects\\node-shell-quote\\index.js b \'c d\'');
+
+	t.end();
+});
+
+test("chars for windows paths don't break out", function (t) {
+	var x = '`:\\a\\b';
+	t.equal(quote([x]), "'`:\\a\\b'");
+	t.end();
 });


### PR DESCRIPTION
The quote function was severely broken:

1. operators were quoted; should have been output literally

2. backslashes were used as escapes inside single-quoted strings (they lose the escape meaning inside single quoted strings)

3. Ugliness - when no quoting was needed, it was applied anyway examples:
   - VAR=value needs no quoting. it was output as VAR\=value
   - main^{commit} needs no quoting. was output as main\^\{commit\}

Fixes Mergesium/node-shell-quote#1 and ljharb/shell-quote#11

**Merge Conflict Note**: This branch is based on v1.0.0 from substack's repo, meaning other forks in substack's network can merge it cleanly. Due to the refactor at  553fdfc3 there is now a merge conflict (Originally the quote functions were in `index.js`, at 553fdfc3 they were moved to `quote.js`). To resolve the merge conflict onto the refactored lib, you can use the `quote.js` file from 6e9606b, although it also contains the Unicode/unprintables escaping functionality and `quote_ascii()`, which are part of my 2.0.0 release, as well as the various fixes from substack's fork network that I was able to find. See CHANGELOG.md at https://github.com/Mergesium/node-shell-quote/commit/6e9606b7ecebe9024e8453954f59a600d33e3977#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed for summary. I'll be happy to answer questions.

Author-Rebase-Consent: https://No-rebase.github.io