### PR TITLE
Reduce package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
 	},
 	"publishConfig": {
 		"ignore": [
-			".github/workflows"
+			".github/workflows",
+			"example",
+			"CHANGELOG.md"
 		]
 	}
 }


### PR DESCRIPTION
Avoids bundling large files like the changelog into the distributed package.

Unpacked size: 45.5 kB -> 12.3 kB
Packaged size: 15.7 kB -> 5 kB

Before:

```
npm pack --dry-run
npm notice
npm notice 📦  shell-quote@1.8.1
npm notice === Tarball Contents ===
npm notice 493B   .eslintrc
npm notice 582B   .github/FUNDING.yml
npm notice 229B   .nycrc
npm notice 21.7kB CHANGELOG.md
npm notice 1.1kB  LICENSE
npm notice 3.6kB  README.md
npm notice 128B   example/env.js
npm notice 106B   example/op.js
npm notice 118B   example/parse.js
npm notice 109B   example/quote.js
npm notice 87B    index.js
npm notice 1.8kB  package.json
npm notice 5.2kB  parse.js
npm notice 457B   quote.js
npm notice 295B   security.md
npm notice 642B   test/comment.js
npm notice 483B   test/env_fn.js
npm notice 1.9kB  test/env.js
npm notice 3.1kB  test/op.js
npm notice 1.4kB  test/parse.js
npm notice 1.4kB  test/quote.js
npm notice 565B   test/set.js
npm notice === Tarball Details ===
npm notice name:          shell-quote
npm notice version:       1.8.1
npm notice filename:      shell-quote-1.8.1.tgz
npm notice package size:  15.7 kB
npm notice unpacked size: 45.4 kB
npm notice shasum:        1e24f9b8fdc41b7c006d3efa6a94a0fa37f84a71
npm notice integrity:     sha512-ahgRvFkK1QU7C[...]k7EfVOHB4N27g==
npm notice total files:   22
npm notice
shell-quote-1.8.1.tgz
```

After:

```
npm pack --dry-run
npm notice
npm notice 📦  shell-quote@1.8.1
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 3.6kB README.md
npm notice 87B   index.js
npm notice 1.8kB package.json
npm notice 5.2kB parse.js
npm notice 457B  quote.js
npm notice === Tarball Details ===
npm notice name:          shell-quote
npm notice version:       1.8.1
npm notice filename:      shell-quote-1.8.1.tgz
npm notice package size:  5.0 kB
npm notice unpacked size: 12.3 kB
npm notice shasum:        452f8420a04b0105f9ac07200a8a35270ce13802
npm notice integrity:     sha512-5OlDuabL6IX/F[...]MoW/nSy7BNO7g==
npm notice total files:   6
npm notice
shell-quote-1.8.1.tgz
```

After including `tests` back in the package contents:

```
npm notice
npm notice 📦  shell-quote@1.8.1
npm notice === Tarball Contents ===
npm notice 582B  .github/FUNDING.yml
npm notice 1.1kB LICENSE
npm notice 3.6kB README.md
npm notice 87B   index.js
npm notice 1.8kB package.json
npm notice 5.2kB parse.js
npm notice 457B  quote.js
npm notice 295B  security.md
npm notice 642B  test/comment.js
npm notice 483B  test/env_fn.js
npm notice 1.9kB test/env.js
npm notice 3.1kB test/op.js
npm notice 1.4kB test/parse.js
npm notice 1.4kB test/quote.js
npm notice 565B  test/set.js
npm notice === Tarball Details ===
npm notice name:          shell-quote                        
npm notice version:       1.8.1                              
npm notice filename:      shell-quote-1.8.1.tgz              
npm notice package size:  7.7 kB                             
npm notice unpacked size: 22.6 kB                            
npm notice shasum:        10ffd15b781fa40af0826200d9114e63962db220
npm notice integrity:     sha512-9patS5xjm4tgs[...]ZK2kBuKah+e7g==
npm notice total files:   15                                 
npm notice
shell-quote-1.8.1.tgz
```