### PR TITLE
Fix unnecessary backslash escaping in single quotes

### DIFF
--- a/quote.js
+++ b/quote.js
@@ -8,8 +8,8 @@ module.exports = function quote(xs) {
 		if (s && typeof s === 'object') {
 			return s.op.replace(/(.)/g, '\\$1');
 		}
-		if ((/["\s]/).test(s) && !(/'/).test(s)) {
-			return "'" + s.replace(/(['\\])/g, '\\$1') + "'";
+		if ((/["\s\\]/).test(s) && !(/'/).test(s)) {
+			return "'" + s.replace(/(['])/g, '\\$1') + "'";
 		}
 		if ((/["'\s]/).test(s)) {
 			return '"' + s.replace(/(["\\$`!])/g, '\\$1') + '"';

--- a/test/quote.js
+++ b/test/quote.js
@@ -22,7 +22,11 @@ test('quote', function (t) {
 	t.equal(quote(['><;{}']), '\\>\\<\\;\\{\\}');
 	t.equal(quote(['a', 1, true, false]), 'a 1 true false');
 	t.equal(quote(['a', 1, null, undefined]), 'a 1 null undefined');
-	t.equal(quote(['a\\x']), 'a\\\\x');
+	t.equal(quote(['a\\x']), "'a\\x'");
+	t.equal(quote(['a"b']), '\'a"b\'');
+	t.equal(quote(['"a"b"']), '\'"a"b"\'');
+	t.equal(quote(['a\\"b']), '\'a\\"b\'');
+	t.equal(quote(['a\\b']), '\'a\\b\'');
 	t.end();
 });
 
@@ -45,7 +49,7 @@ test('quote windows paths', { skip: 'breaking change, disabled until 2.x' }, fun
 
 test("chars for windows paths don't break out", function (t) {
 	var x = '`:\\a\\b';
-	t.equal(quote([x]), '\\`\\:\\\\a\\\\b');
+	t.equal(quote([x]), "'`:\\a\\b'");
 	t.end();
 });
 


### PR DESCRIPTION
Remove backslash escaping when wrapping arguments in single quotes, since single quotes preserve backslashes literally in shell. This fixes #15 

As a concrete example showing the new correct behavior:

```
> console.log(toEscape)
\"
> console.log(quote([toEscape]))
'\"'
```