### PR TITLE
[Fix] `parse`: a backslash inside single quotes must not escape the closing quote

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -25,7 +25,7 @@ var CONTROL = /** @type {const} */ ('(?:') + /** @type {const} */ ([
 var controlRE = new RegExp('^' + CONTROL + '$');
 var META = /** @type {const} */ ('|&;()<> \\t');
 var SINGLE_QUOTE = /** @type {const} */ ('"((\\\\"|[^"])*?)"');
-var DOUBLE_QUOTE = /** @type {const} */ ('\'((\\\\\'|[^\'])*?)\'');
+var DOUBLE_QUOTE = /** @type {const} */ ('\'([^\']*?)\'');
 var hash = /^#$/;
 
 var SQ = /** @type {const} */ ("'");

--- a/test/parse.js
+++ b/test/parse.js
@@ -2,6 +2,7 @@
 
 var test = require('tape');
 var parse = require('../').parse;
+var quote = require('../').quote;
 
 test('parse shell commands', function (t) {
 	t.same(parse(''), [], 'parses an empty string');
@@ -32,6 +33,12 @@ test('parse shell commands', function (t) {
 	t.same(parse('a\\ b"c d"\\ e f'), ['a bc d e', 'f']);
 	t.same(parse('a\\ b"c d"\\ e\'f g\' h'), ['a bc d ef g', 'h']);
 	t.same(parse("x \"bl'a\"'h'"), ['x', "bl'ah"]);
+
+	// inside single quotes everything is literal, so a backslash does not escape
+	// the closing quote and a quoted token must end at its first closing quote
+	t.same(parse("'\\' '\\'"), ['\\', '\\'], 'single-quoted backslashes parse as two separate tokens');
+	t.same(parse("'\\'\\''"), ["\\'"], 'single-quoted backslash joined with an escaped quote');
+	t.same(parse(quote(['\\', '\\'])), ['\\', '\\'], 'quote/parse round-trips a pair of backslashes');
 	t.same(parse("x bl^'a^'h'", {}, { escape: '^' }), ['x', "bl'a'h"]);
 	t.same(parse('abcH def', {}, { escape: 'H' }), ['abc def']);
 


### PR DESCRIPTION
In a POSIX shell a single-quoted string is fully literal: a backslash inside single quotes is just a backslash and never escapes the closing quote. `parse`'s scanner already follows this (rule 1 in the comment in `parse.js`; the single-quote branch only does `out += c`), but the chunker regex that splits the input into tokens does not.

The single-quote matcher is:

```js
var DOUBLE_QUOTE = '\'((\\\\\'|[^\'])*?)\'';
```

The `\'` alternative lets the regex treat a backslash-then-quote as an escaped quote inside a single-quoted token, so it walks past the real closing quote and keeps consuming the trailing whitespace and the next token. Two single-quoted tokens that end in a backslash get merged into one:

```js
parse("'\\' '\\'")   // returns ["\\ \\"]  (one token); expected ["\\", "\\"]
```

This also breaks round-tripping through `quote`. Since #20, `quote` wraps a backslash in single quotes without escaping it (`quote(["\\"]) === "'\\'"`), which is correct, but `parse` cannot read its own output back:

```js
parse(quote(["\\", "\\"]))   // returns ["\\ \\"]; expected ["\\", "\\"]
```

The fix drops the `\'` alternative so the single-quote matcher ends at the first closing quote, matching the scanner and POSIX:

```js
var DOUBLE_QUOTE = '\'([^\']*?)\'';
```

The normal way to place a quote next to single-quoted text, `'\''` (close, escaped quote, reopen), is unaffected: `parse("'\\'\\''")` still returns `["\\'"]`.

Added three assertions in `test/parse.js` (the two-token case, the `quote`/`parse` round-trip, and the `'\''` preservation case). The full suite passes. Reverting only the `parse.js` change makes the two behavioral assertions fail.
